### PR TITLE
Added better HTTP error handling.

### DIFF
--- a/src/PortableRest/Extensions/HttpResponseMessageExtensions.cs
+++ b/src/PortableRest/Extensions/HttpResponseMessageExtensions.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using Newtonsoft.Json;
+
+namespace PortableRest.Extensions
+{
+    /// <summary>
+    /// Extension methods for reading response content.
+    /// </summary>
+    public static class HttpResponseMessageExtensions
+    {
+        /// <summary>
+        /// Gets the content as the specified type synchronously.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="message">The message.</param>
+        /// <returns></returns>
+        public static T GetContentAs<T>(this HttpResponseMessage message)
+        {
+            var task = message.Content.ReadAsStringAsync();
+            task.Wait();
+            return JsonConvert.DeserializeObject<T>(task.Result);
+        }
+
+        /// <summary>
+        /// Gets the content as a string synchronously.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        /// <returns></returns>
+        public static string ReadAsString(this HttpResponseMessage message)
+        {
+            var task = message.Content.ReadAsStringAsync();
+            task.Wait();
+            return task.Result;
+        }
+    }
+}

--- a/src/PortableRest/HttpResponseException.cs
+++ b/src/PortableRest/HttpResponseException.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Net.Http;
+
+namespace PortableRest
+{
+    /// <summary>
+    /// Exception containing the HTTP response, in case of an unsuccessfull status code.
+    /// </summary>
+    public class HttpResponseException : Exception
+    {
+        /// <summary>
+        /// Gets the response.
+        /// </summary>
+        /// <value>
+        /// The response.
+        /// </value>
+        public HttpResponseMessage Response { get; private set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HttpResponseException"/> class.
+        /// </summary>
+        /// <param name="response">The response.</param>
+        public HttpResponseException(HttpResponseMessage response)
+            : base("Response status code does not indicate success.")
+        {
+            if(response == null) throw new ArgumentNullException("response");
+            Response = response;
+        }
+    }
+}

--- a/src/PortableRest/PortableRest.csproj
+++ b/src/PortableRest/PortableRest.csproj
@@ -72,8 +72,10 @@
   <ItemGroup>
     <Compile Include="ContentTypes.cs" />
     <Compile Include="EncodedParameter.cs" />
+    <Compile Include="Extensions\HttpResponseMessageExtensions.cs" />
     <Compile Include="Extensions\StreamExtensions.cs" />
     <Compile Include="Extensions\TypeExtensions.cs" />
+    <Compile Include="HttpResponseException.cs" />
     <Compile Include="ParameterEncoding.cs" />
     <Compile Include="PortableRestException.cs" />
     <Compile Include="RestClient.cs" />

--- a/src/PortableRest/RestClient.cs
+++ b/src/PortableRest/RestClient.cs
@@ -14,7 +14,6 @@ using Newtonsoft.Json;
 
 namespace PortableRest
 {
-
     /// <summary>
     /// Base client to create REST requests and process REST responses. Uses <see cref="HttpClient"/> as the underlying transport.
     /// </summary>
@@ -173,8 +172,9 @@ namespace PortableRest
 
             HttpResponseMessage response = null;
             response = await _client.SendAsync(message);
-            response.EnsureSuccessStatusCode();
-
+            if(! response.IsSuccessStatusCode)
+                throw new HttpResponseException(response);
+            
             var responseContent = await response.Content.ReadAsStringAsync();
 
             if (restRequest.ReturnRawString)


### PR DESCRIPTION
A HttpRequestException is not enough when your REST API returns error
content that your REST Client should use. E.g. a 400 Bad Request may
contain valuable information as to what went wrong. 

I changed the ExecuteAsync to throw an HttpResponseException if not successful,
containing the response message. I also added 2 extension methods for
reading the content synchronously. See the test for an example.
